### PR TITLE
Created optional flag for copying content

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ hubdb-copier
 - `-t, --target-token <token>`: Target HubSpot API token (optional if set in .env)
 - `-V, --version`: Output the version number
 - `-h, --help`: Display help information
+- `--copy-content`: Copy table content along with schema
 
 ### Example
 

--- a/src/hubspot-client.ts
+++ b/src/hubspot-client.ts
@@ -5,6 +5,7 @@ import {
   TableCreateRequest,
   HubDBTable,
   ImportConfig,
+  HubDBColumn,
 } from "./types";
 
 export class HubSpotClient {
@@ -151,5 +152,63 @@ export class HubSpotClient {
       `/cms/v3/hubdb/tables/${tableId}/draft/publish`
     );
     return response.data;
+  }
+
+  async getTableByName(name: string): Promise<HubDBTable | null> {
+    try {
+      const response = await this.client.get(`/cms/v3/hubdb/tables`, {
+        params: { name },
+      });
+
+      if (
+        response.data &&
+        response.data.results &&
+        response.data.results.length > 0
+      ) {
+        return response.data.results[0];
+      }
+
+      return null;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        console.error("Get table by name error:", {
+          status: error.response?.status,
+          data: error.response?.data,
+        });
+      }
+      throw error;
+    }
+  }
+
+  async addColumnsToTable(
+    tableId: string,
+    columns: HubDBColumn[],
+    name: string,
+    label: string
+  ): Promise<void> {
+    try {
+      console.log("Adding columns to table", tableId, name, label, columns);
+      const response = await this.client.patch(
+        `/cms/v3/hubdb/tables/${tableId}/draft`,
+        {
+          columns: columns,
+          name: name,
+          label: label,
+        }
+      );
+
+      if (!response.data || !response.data.id) {
+        console.error("Invalid add columns response:", response.data);
+        throw new Error("Invalid response from add columns API");
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        console.error("Add columns to table error:", {
+          status: error.response?.status,
+          data: error.response?.data,
+        });
+      }
+      throw error;
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,82 +94,120 @@ async function copyTable(
       );
     }
 
-    // Create new table in target portal
-    spinner.text = `Creating table ${table.name} in target portal...`;
-    const createTableRequest = {
-      name: table.name,
-      label: table.label,
-      columns: table.columns
-        .filter((column) => column.type !== "FOREIGN_ID")
-        .map((column) => {
-          const baseColumn = {
-            name: column.name,
-            type: column.type,
-            label: column.label,
+    // Check if table exists in target portal
+    spinner.text = `Checking if table ${table.name} exists in target portal...`;
+    const existingTable = await targetClient.getTableByName(table.name);
+
+    let newTable: HubDBTable | undefined;
+
+    const filteredColumns = table.columns
+      .filter((column) => column.type !== "FOREIGN_ID")
+      .map((column) => {
+        const baseColumn = {
+          name: column.name,
+          type: column.type,
+          label: column.label,
+          description: column.description,
+        };
+
+        if (column.type === "SELECT" || column.type === "MULTISELECT") {
+          return {
+            ...baseColumn,
+            options: (column.options?.length
+              ? column.options
+              : [
+                  {
+                    name: "default",
+                    label: "Default Option",
+                  },
+                ]
+            ).map((opt) => ({
+              name: opt.name,
+              label: opt.label,
+            })),
           };
+        }
 
-          if (column.type === "SELECT" || column.type === "MULTISELECT") {
-            return {
-              ...baseColumn,
-              options: (column.options?.length
-                ? column.options
-                : [
-                    {
-                      name: "default",
-                      label: "Default Option",
-                    },
-                  ]
-              ).map((opt) => ({
-                name: opt.name,
-                label: opt.label,
-              })),
-            };
-          }
+        if (column.type === "FILE") {
+          return {
+            ...baseColumn,
+            fileType: column.fileType || "DOCUMENT", // Ensure fileType is set
+          };
+        }
 
-          if (column.type === "FILE") {
-            return {
-              ...baseColumn,
-              fileType: column.fileType || "DOCUMENT", // Ensure fileType is set
-            };
-          }
+        return baseColumn;
+      });
 
-          return baseColumn;
-        }),
-      allowPublicApiAccess: true,
-      useForPages: Boolean(table.useForPages),
-      allowChildTables: Boolean(table.allowChildTables),
-      enableChildTablePages: Boolean(table.enableChildTablePages),
-    };
+    if (existingTable) {
+      spinner.succeed(
+        `Table ${table.name} already exists in target portal. Adding missing columns...`
+      );
 
-    // Remove any undefined values
-    const cleanRequest = JSON.parse(JSON.stringify(createTableRequest));
+      // Build the request for adding columns
+      const addColumnsRequest = {
+        columns: filteredColumns,
+        name: table.name,
+        label: table.label,
+      };
 
-    console.log(
-      "Creating table with request:",
-      JSON.stringify(cleanRequest, null, 2)
-    );
-    const newTable = await targetClient.createTable(cleanRequest);
+      // Remove any undefined values
+      const cleanAddColumnsRequest = JSON.parse(
+        JSON.stringify(addColumnsRequest)
+      );
 
-    console.log(chalk.blue("\nCreated table details:"));
-    console.log(
-      JSON.stringify(
-        {
-          id: newTable.id,
-          name: newTable.name,
-          label: newTable.label,
-          columnCount: newTable.columnCount,
-        },
-        null,
-        2
-      )
-    );
-    spinner.succeed(
-      `Successfully created table in target portal: ${newTable.name} (ID: ${newTable.id})`
-    );
+      // Add all columns to existing table
+      await targetClient.addColumnsToTable(
+        existingTable.id,
+        cleanAddColumnsRequest.columns,
+        cleanAddColumnsRequest.name,
+        cleanAddColumnsRequest.label
+      );
+      spinner.succeed(`Added columns to table: ${table.name}`);
+    } else {
+      // Create new table in target portal
+      spinner.text = `Creating table ${table.name} in target portal...`;
+      const createTableRequest = {
+        name: table.name,
+        label: table.label,
+        columns: filteredColumns,
+        allowPublicApiAccess: true,
+        useForPages: Boolean(table.useForPages),
+        allowChildTables: Boolean(table.allowChildTables),
+        enableChildTablePages: Boolean(table.enableChildTablePages),
+      };
+
+      // Remove any undefined values
+      const cleanRequest = JSON.parse(JSON.stringify(createTableRequest));
+
+      console.log(
+        "Creating table with request:",
+        JSON.stringify(cleanRequest, null, 2)
+      );
+      newTable = await targetClient.createTable(cleanRequest);
+
+      console.log(chalk.blue("\nCreated table details:"));
+      console.log(
+        JSON.stringify(
+          {
+            id: newTable.id,
+            name: newTable.name,
+            label: newTable.label,
+            columnCount: newTable.columnCount,
+          },
+          null,
+          2
+        )
+      );
+      spinner.succeed(
+        `Successfully created table in target portal: ${newTable.name} (ID: ${newTable.id})`
+      );
+    }
 
     if (copyContent && csvData) {
       // Import data to target table
-      spinner.text = `Importing data to target table (ID: ${newTable.id})...`;
+      spinner.text = `Importing data to target table (ID: ${
+        existingTable ? existingTable.id : newTable?.id
+      })...`;
 
       // Create column mappings based on the CSV header (which matches source column names)
       // The source numbers start at 1 (not 0) according to the docs
@@ -181,23 +219,27 @@ async function copyTable(
         }));
 
       console.log(chalk.blue("\nImporting to table with details:"), {
-        tableId: newTable.id,
-        tableName: newTable.name,
+        tableId: existingTable ? existingTable.id : newTable!.id,
+        tableName: table.name,
         csvDataLength: csvData.length,
         columnMappings,
       });
 
       try {
-        await targetClient.importTable(newTable.id, csvData, {
-          columnMappings,
-          skipRows: 1,
-          format: "csv",
-          separator: ",",
-          encoding: "utf-8",
-          resetTable: true,
-        });
+        await targetClient.importTable(
+          existingTable ? existingTable.id : newTable!.id,
+          csvData,
+          {
+            columnMappings,
+            skipRows: 1,
+            format: "csv",
+            separator: ",",
+            encoding: "utf-8",
+            resetTable: true,
+          }
+        );
         spinner.succeed(
-          `Successfully imported data to target table: ${newTable.name}`
+          `Successfully imported data to target table: ${table.name}`
         );
       } catch (importError) {
         console.error("Import error details:", importError);
@@ -207,8 +249,10 @@ async function copyTable(
 
     // Publish the table
     spinner.text = `Publishing target table...`;
-    await targetClient.publishTable(newTable.id);
-    spinner.succeed(`Successfully published table: ${newTable.name}`);
+    await targetClient.publishTable(
+      existingTable ? existingTable.id : newTable!.id
+    );
+    spinner.succeed(`Successfully published table: ${table.name}`);
   } catch (error) {
     spinner.fail(`Failed to copy table: ${table.name}`);
     if (axios.isAxiosError(error) && error.response) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,13 @@ async function copyTable(
             };
           }
 
+          if (column.type === "FILE") {
+            return {
+              ...baseColumn,
+              fileType: column.fileType || "DOCUMENT", // Ensure fileType is set
+            };
+          }
+
           return baseColumn;
         }),
       allowPublicApiAccess: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,4 +98,5 @@ export interface ImportConfig {
 export interface CliOptions {
   sourceToken: string;
   targetToken: string;
+  copyContent?: boolean;
 }


### PR DESCRIPTION
The script now only copies schema by default. But if you set the `--copy-content` flag, then it theoretically will execute the content copying functionality as well (though it doesn't appear to be working at the moment).

Also, included a fix for fileType columns.

And added the ability to update existing tables by adding missing columns. This will also remove any deleted columns from the target table.

Lastly, this includes support for column descriptions.