### PR TITLE
Support for --update-existing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ hubdb-copier
 - `-V, --version`: Output the version number
 - `-h, --help`: Display help information
 - `--copy-content`: Copy table content along with schema
+- `--update-existing`: Update existing tables in target portal
 
 ### Example
 
@@ -102,8 +103,15 @@ hubdb-copier
    npm run build
    ```
 5. Run in development mode:
+
    ```bash
    npm run dev
+   ```
+
+   To pass CLI options in development mode, add them after a double dash (--). For example, to include the option of `--update-existing`:
+
+   ```
+   npm run dev -- --update-existing
    ```
 
 ## License

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,4 +99,5 @@ export interface CliOptions {
   sourceToken: string;
   targetToken: string;
   copyContent?: boolean;
+  updateExisting?: boolean;
 }


### PR DESCRIPTION
To ensure that I don't accidentally add missing columns to an existing table, I added a CLI option for `--update-existing` that defaults to false.

I also documented in the README how to pass options like that when testing locally.

Lastly, I commented out a console log for "API Response" that was generating way too much noise.